### PR TITLE
feat: add character limit to the action

### DIFF
--- a/front-end/src/app/tabs/dashboard/deadlines/manageDeadline.component.ts
+++ b/front-end/src/app/tabs/dashboard/deadlines/manageDeadline.component.ts
@@ -52,11 +52,11 @@ import { Deadline } from '@models/deadline.model';
           </ion-label>
           <ion-input [(ngModel)]="deadline.name"></ion-input>
         </ion-item>
-        <ion-item [class.fieldHasError]="hasFieldAnError('action')">
+        <ion-item [class.fieldHasError]="hasFieldAnError('action')" [counter]="true">
           <ion-label position="stacked">
             {{ 'DEADLINES.ACTION' | translate }}
           </ion-label>
-          <ion-input [(ngModel)]="deadline.action"></ion-input>
+          <ion-input [(ngModel)]="deadline.action" maxlength="15"></ion-input>
         </ion-item>
         <ion-item *ngIf="deadline.action" [class.fieldHasError]="hasFieldAnError('actionColor')">
           <ion-label position="stacked">
@@ -182,5 +182,9 @@ export class ManageDeadlineComponent {
     ];
     const alert = await this.alertCtrl.create({ header, subHeader, buttons });
     alert.present();
+  }
+
+  customCounterFormatter(inputLength: number, maxLength: number) {
+    return `${maxLength - inputLength} characters remaining`;
   }
 }


### PR DESCRIPTION
if the deadline.action text is too long it's truncated when displayed in the chip.

this possible fix sets the character limit to 15 adding a counter to the input.

another option would be deciding to limit the action to a prefefined set of options.